### PR TITLE
Update mediawiki_extractor.py, Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# ignore everything in the dataset folder
+dataset/*
+
+# exception
+!dataset/fetched_titles.json

--- a/mediawiki_extractor.py
+++ b/mediawiki_extractor.py
@@ -1,13 +1,24 @@
 # Nov. 25th 2021
 # Molly Jacobsen
+# Danial Motamedi Mehr
+# Tigran Ionnisian
 
-# Sample script using wikimedia API to extract data into CSV files
+# Data collection script
 
 import requests
+import threading
 import json
 import time
 import mwparserfromhell
+import msvcrt
+import os
 
+
+STOP_KEY = b'q' # pressing q will stop the script
+
+# when set to true, the program stops executing the script gracefully
+global stop_signal
+stop_signal = False
 
 S = requests.Session()
 S.headers.update({"User-Agent": "script (danialmtmdmhr23@gmail.com)", "Accept-encoding": "gzip"})
@@ -48,9 +59,13 @@ def get_all_revisions(title: str) -> list:
     # we only have a single page in query
     PAGE = DATA["query"]["pages"][0]
     revisions = PAGE["revisions"]
+    process_revision_contents(revisions)
+
+    report_progress(len(revisions))
 
     # "continue" field marks unfinished query
-    while "continue" in DATA:
+    # stop_signal is set by the user by pressing the stop key
+    while "continue" in DATA and not stop_signal:
 
         # modify parameters to include last query's rvcontinue
         PARAMS.update({"rvcontinue": DATA["continue"]["rvcontinue"]})
@@ -64,29 +79,29 @@ def get_all_revisions(title: str) -> list:
 
         PAGE = DATA["query"]["pages"][0]
 
+        revisions_added = PAGE["revisions"]
+        process_revision_contents(revisions_added)
+
         # append to the revision list
-        revisions += PAGE["revisions"]
+        revisions += revisions_added
+
+        report_progress(len(revisions))
 
     end_time = time.time()  # for benchmarking
 
-    print("Total time for page \"" + title + "\":", end_time - start_time)  # for benchmarking
-    print("Total revisions:", len(revisions))  # for benchmarking
+    print("\nTotal time for page \"" + title + "\":", end_time - start_time)  # for benchmarking
 
     return revisions
 
 
-def main():
-    revisions = get_all_revisions("SQLite")
-    count = count_reverts(revisions)
-    process_revision_contents(revisions)
-    print("Reverted count:", count)
-    print("Revision plaintext example:\n", revisions[-1]["slots"]["main"]["content"])
-
-
-def save_revisions(revisions, filename):
-    with open(filename, 'w') as f:
-        for i in revisions:
-            f.write("%s\n" % i)
+def save_page(page, filename):
+    """
+    Saves a page to disk. A page is a dict with two keys: "title" and "revisions"
+    """
+    with open(filename, 'w+') as f:
+        json.dump(page, f)
+        f.write('')
+        print('Page revision data saved to', filename)
 
 
 def count_reverts(revisions):
@@ -114,6 +129,80 @@ def process_revision_contents(revisions: list)-> None:
         rev["slots"]["main"]["content"] = stripped_content
 
 
+def report_progress(i):
+    print(f"Progress: {i} items", end='\r')
+
+
+
+def detect_stop_signal():
+    """
+    Stops the program when it receives a key stroke that matches STOP_KEY
+    """
+    while True:
+        ch = msvcrt.getch()
+        if ch == STOP_KEY:
+            print('\n\n*** Quitting script ***\n\n')
+            global stop_signal
+            stop_signal = True
+            exit(0)
+
+
+
+def main():
+    # load titles
+    with open('titles.json', "r") as f:
+        titles = json.load(f)
+
+    # change working directory
+    os.chdir('dataset')
+
+    # try to load previously fetched titles
+    try:
+        with open('titles_fetched.json', 'r') as f:
+            titles_fetched = json.load(f)
+    except FileNotFoundError:
+        titles_fetched = {}
+    
+    
+    print("Press Q at any point to stop the script gracefully.")
+
+
+    for index, title in enumerate(titles):
+        
+        # already got the rev data from this page
+        if title in titles_fetched:
+            continue
+        
+        revisions = get_all_revisions(title)
+
+        # dont save if we get interrupted
+        if stop_signal:
+            break
+
+        # null check (there was an error in the request response)
+        if not revisions:
+            break
+        
+        # save rev data to disk
+        save_page({"page" : title, "revisions": revisions}, str(index) +'.json')
+
+        # update and save titles_fetched
+        titles_fetched[title] = index
+        with open('titles_fetched.json', 'w+') as f:
+            json.dump(titles_fetched, f)
+            f.write('')
+    
+    print("Done.")
+
+
 
 if __name__ == "__main__":
-    main()
+    
+    # this thread just waits for the STOP_KEY key stroke (set at top of the script)
+    wait_thread = threading.Thread(name='wait_for_quit_key', target=detect_stop_signal)
+
+    # main work thread
+    main_thread = threading.Thread(name='script_main', target=main)
+
+    wait_thread.start()
+    main_thread.start()


### PR DESCRIPTION
The mediawiki_extractor.py script is now functional, and can be used to collect and save revision data.
Added .gitignore to prevent git from tracking the dataset itself. An exception to this rule is titles_fetched.json which tracks which titles have already been fetched by at least one team member, so we don't download the same page twice.